### PR TITLE
Fix a possible security issue with spoofing for v2.7

### DIFF
--- a/lib/paperclip/upfile.rb
+++ b/lib/paperclip/upfile.rb
@@ -7,14 +7,7 @@ module Paperclip
   module Upfile
     # Infer the MIME-type of the file from the extension.
     def content_type
-      types = MIME::Types.type_for(self.original_filename)
-      if types.length == 0
-        type_from_file_command
-      elsif types.length == 1
-        types.first.content_type
-      else
-        iterate_over_array_to_find_best_option(types)
-      end
+      type_from_file_command
     end
 
     def iterate_over_array_to_find_best_option(types)


### PR DESCRIPTION
This is a patch that addresses this problem: https://robots.thoughtbot.com/paperclip-security-release

The description is the following:
```
There is an issue where if an HTML file is uploaded with a .html
extension, but the content type is listed as being `image/jpeg`, this
will bypass a validation checking for images. But it will also pass the
spoof check, because a file named .html and containing actual HTML
passes the spoof check.

This change makes it so that we also check the supplied content type. So
even if the file contains HTML and ends with .html, it doesn't match the
content type of `image/jpeg` and so it fails.
```
The patch was inspired by the commit to a recent versions: https://github.com/thoughtbot/paperclip/commit/9aee4112f36058cd28d5fe4a006d6981bd1eda57