### PR TITLE
fix: Replace deprecated URI.escape with URI::DEFAULT_PARSER.escape

### DIFF
--- a/lib/paperclip/url_generator.rb
+++ b/lib/paperclip/url_generator.rb
@@ -58,7 +58,7 @@ module Paperclip
     end
 
     def escape_url(url)
-      (url.respond_to?(:escape) ? url.escape : URI.escape(url)).gsub(/(\/.+)\?(.+\.)/, '\1%3F\2')
+      (url.respond_to?(:escape) ? url.escape : URI::DEFAULT_PARSER.escape(url)).gsub(/(\/.+)\?(.+\.)/, '\1%3F\2')
     end
   end
 end

--- a/lib/paperclip/version.rb
+++ b/lib/paperclip/version.rb
@@ -1,3 +1,3 @@
 module Paperclip
-  VERSION = "2.7.0" unless defined? Paperclip::VERSION
+  VERSION = "2.7.0.2" unless defined? Paperclip::VERSION
 end


### PR DESCRIPTION
## Summary

`URI.escape` was deprecated in Ruby 2.7 and emits a warning on every call. `URI::DEFAULT_PARSER.escape` produces identical output without the deprecation warning.

## Problem

In services running Ruby 2.7+ with Paperclip URL generation (e.g. `escape: true`), every URL escape triggers:
```
warning: URI.escape is obsolete
```
In production, this produces ~12,500 deprecation warnings per log cycle in core-api-ro alone.

## Changes

- `lib/paperclip/url_generator.rb`: `URI.escape(url)` → `URI::DEFAULT_PARSER.escape(url)`
- `lib/paperclip/version.rb`: Bump to `2.7.0.2`

## Verification

`URI::DEFAULT_PARSER.escape` and `URI.escape` produce byte-identical output for all inputs. The only difference is the absence of the deprecation warning.

Based on tag `v2.7.0.fix-01`.